### PR TITLE
Change some multiline behaviors

### DIFF
--- a/Sources/CLTLogger.swift
+++ b/Sources/CLTLogger.swift
@@ -94,7 +94,7 @@ public struct CLTLogger : LogHandler {
 		/** Multiline logs are allowed and logs are printed after the log, one line per metadata (metadata are never multiline). */
 		case allMultiline
 		
-		public static let `default` = Self.disallowMultiline
+		public static let `default` = Self.disallowMultilineButMetadataOnNewLines
 	}
 	
 	public struct Constants : CLTLogger_Sendable {

--- a/Sources/String+Utils.swift
+++ b/Sources/String+Utils.swift
@@ -99,7 +99,8 @@ internal extension String {
 				prefix = ""
 			}
 			
-			if Self.newLines.contains(scalar) {
+			let isNewLine = Self.newLines.contains(scalar)
+			if isNewLine {
 				hasProcessedNewLines = true
 				switch newLineProcessing {
 					case .none:           return prefix + String(scalar)
@@ -123,7 +124,7 @@ internal extension String {
 						specialCharState = (scalar, 0)
 						return prefix + ""
 					}
-					let escaped = scalar.escaped(asASCII: asASCII)
+					let escaped = scalar.escaped(asASCII: asASCII || isNewLine)
 //#if swift(>=5.4)
 //					return prefix + (octothorpLevel == 0 ? escaped : escaped.replacingOccurrences(of: #"\"#, with: #"\"# + octothorps, options: .literal))
 //#else

--- a/Tests/CLTLoggerTests/CLTLoggerTests.swift
+++ b/Tests/CLTLoggerTests/CLTLoggerTests.swift
@@ -8,10 +8,12 @@ import XCTest
 
 final class CLTLoggerTests : XCTestCase {
 	
+	static let multilineMode: CLTLogger.MultilineMode = .default
+	
 	override class func setUp() {
 		/* ⚠️ Also change in the testBasicLogOutputWithAllEmojiSets method if changed here.
 		 * We have not created a variable because we would have to use the @Sendable annotation, which we cannot as we support Swift 5.2. */
-		LoggingSystem.bootstrap{ _ in CLTLogger() }
+		LoggingSystem.bootstrap{ _ in CLTLogger(multilineMode: Self.multilineMode) }
 	}
 	
 	/* From <https://apple.github.io/swift-log/docs/current/Logging/Protocols/LogHandler.html#treat-log-level-amp-metadata-as-values>. */
@@ -95,7 +97,7 @@ final class CLTLoggerTests : XCTestCase {
 		XCTAssertTrue(true, "We only want to see how the log look, so please see the logs.")
 		
 		for emojiSet in EmojiSet.allCases {
-			LoggingSystem.bootstrapInternal{ _ in CLTLogger(constantsByLevel: CLTLogger.defaultConstantsByLogLevelForEmoji(on: .standardError, forcedEmojiSet: emojiSet)) }
+			LoggingSystem.bootstrapInternal{ _ in CLTLogger(multilineMode: Self.multilineMode, constantsByLevel: CLTLogger.defaultConstantsByLogLevelForEmoji(on: .standardError, forcedEmojiSet: emojiSet)) }
 			try FileHandle.standardError.write(contentsOf: Data("\n***** \(emojiSet.rawValue) *****\n".utf8))
 			var logger = Logger(label: "my logger")
 			logger.logLevel = .trace
@@ -109,7 +111,7 @@ final class CLTLoggerTests : XCTestCase {
 		}
 		/* Reset factory.
 		 * ⚠️ Also change in the setUp method if changed here. */
-		LoggingSystem.bootstrapInternal{ _ in CLTLogger() }
+		LoggingSystem.bootstrapInternal{ _ in CLTLogger(multilineMode: Self.multilineMode) }
 	}
 	
 }

--- a/Tests/CLTLoggerTests/CLTLoggerTests.swift
+++ b/Tests/CLTLoggerTests/CLTLoggerTests.swift
@@ -11,7 +11,7 @@ final class CLTLoggerTests : XCTestCase {
 	override class func setUp() {
 		/* ⚠️ Also change in the testBasicLogOutputWithAllEmojiSets method if changed here.
 		 * We have not created a variable because we would have to use the @Sendable annotation, which we cannot as we support Swift 5.2. */
-		LoggingSystem.bootstrap{ _ in CLTLogger(multilineMode: .allMultiline) }
+		LoggingSystem.bootstrap{ _ in CLTLogger() }
 	}
 	
 	/* From <https://apple.github.io/swift-log/docs/current/Logging/Protocols/LogHandler.html#treat-log-level-amp-metadata-as-values>. */
@@ -95,7 +95,7 @@ final class CLTLoggerTests : XCTestCase {
 		XCTAssertTrue(true, "We only want to see how the log look, so please see the logs.")
 		
 		for emojiSet in EmojiSet.allCases {
-			LoggingSystem.bootstrapInternal{ _ in CLTLogger(multilineMode: .allMultiline, constantsByLevel: CLTLogger.defaultConstantsByLogLevelForEmoji(on: .standardError, forcedEmojiSet: emojiSet)) }
+			LoggingSystem.bootstrapInternal{ _ in CLTLogger(constantsByLevel: CLTLogger.defaultConstantsByLogLevelForEmoji(on: .standardError, forcedEmojiSet: emojiSet)) }
 			try FileHandle.standardError.write(contentsOf: Data("\n***** \(emojiSet.rawValue) *****\n".utf8))
 			var logger = Logger(label: "my logger")
 			logger.logLevel = .trace
@@ -109,7 +109,7 @@ final class CLTLoggerTests : XCTestCase {
 		}
 		/* Reset factory.
 		 * ⚠️ Also change in the setUp method if changed here. */
-		LoggingSystem.bootstrapInternal{ _ in CLTLogger(multilineMode: .allMultiline) }
+		LoggingSystem.bootstrapInternal{ _ in CLTLogger() }
 	}
 	
 }

--- a/Tests/CLTLoggerTests/StringEscapingTests.swift
+++ b/Tests/CLTLoggerTests/StringEscapingTests.swift
@@ -117,4 +117,24 @@ final class StringEscapingTests : XCTestCase {
 		XCTAssertEqual(actual, expected)
 	}
 	
+	func testEscapingUtf8Line1() throws {
+		let actual = "weird\u{0085}newline"
+			.processForLogging(
+				escapingMode: .escapeScalars(octothorpLevel: 0, showQuotes: false),
+				newLineProcessing: .escape
+			).string
+		let expected = #"weird\u{0085}newline"#
+		XCTAssertEqual(actual, expected)
+	}
+	
+	func testEscapingUtf8Line2() throws {
+		let actual = "weird\u{0085}newline"
+			.processForLogging(
+				escapingMode: .escapeScalars(octothorpLevel: 0, showQuotes: false),
+				newLineProcessing: .replace(replacement: "yolo")
+			).string
+		let expected = #"weirdyolonewline"#
+		XCTAssertEqual(actual, expected)
+	}
+	
 }


### PR DESCRIPTION
Fixed a bug where UTF-8 newlines were not escaped when disabling newlines.
Changed the default multiline mode.