### PR TITLE
Fix compilation on ancient macOSes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,12 @@ import PackageDescription
 
 let package = Package(
 	name: "clt-logger",
-	/* Not sure how to test for platforms for Swift pre-5.8; let’s not do it. */
+	platforms: [
+		.macOS(.v10_15),
+		.tvOS(.v13),
+		.iOS(.v13),
+		.watchOS(.v6),
+	],
 	products: [
 		.library(name: "CLTLogger", targets: ["CLTLogger"]),
 	],

--- a/Sources/CLTLogger.swift
+++ b/Sources/CLTLogger.swift
@@ -189,7 +189,17 @@ public struct CLTLogger : LogHandler {
 			/* Is the write retried on interrupt?
 			 * We’ll assume yes, but we don’t and can’t know for sure
 			 *  until FileHandle has been migrated to the open-source Foundation. */
-			_ = try? fh.write(contentsOf: data)
+			if #available(macOS 10.15.4, iOS 13.4, tvOS 13.4, watchOS 6.2, *) {
+#if swift(>=5.2) || (!os(macOS) && !os(iOS) && !os(tvOS) && !os(watchOS))
+				_ = try? fh.write(contentsOf: data)
+#else
+				/* Note: This throws an actual objc exception if it fails. */
+				fh.write(data)
+#endif
+			} else {
+				/* Note: This throws an actual objc exception if it fails. */
+				fh.write(data)
+			}
 		}
 	}
 	

--- a/Sources/NSLock+withLock.swift
+++ b/Sources/NSLock+withLock.swift
@@ -1,4 +1,4 @@
-#if os(Linux)
+#if (os(Linux) && swift(<6.0)) || swift(<5.7)
 import Foundation
 
 

--- a/Tests/CLTLoggerTests/CLTLoggerTests.swift
+++ b/Tests/CLTLoggerTests/CLTLoggerTests.swift
@@ -104,6 +104,11 @@ final class CLTLoggerTests : XCTestCase {
 		logger.critical("YAM!\nhere is the second line\nand why not a third one", metadata: ["with": ["metadata", "again"], "because": "42"])
 	}
 	
+#if swift(>=5.2) || (!os(macOS) && !os(iOS) && !os(tvOS) && !os(watchOS))
+	@available(macOS 10.15.4, *)
+	@available(iOS 13.4, *)
+	@available(tvOS 13.4, *)
+	@available(watchOS 6.2, *)
 	func testBasicLogOutputWithAllEmojiSets() throws {
 		XCTAssertTrue(true, "We only want to see how the log look, so please see the logs.")
 		
@@ -124,5 +129,6 @@ final class CLTLoggerTests : XCTestCase {
 		 * ⚠️ Also change in the setUp method if changed here. */
 		LoggingSystem.bootstrapInternal{ _ in CLTLogger(multilineMode: Self.multilineMode) }
 	}
+#endif
 	
 }

--- a/Tests/CLTLoggerTests/EmojiTests.swift
+++ b/Tests/CLTLoggerTests/EmojiTests.swift
@@ -22,6 +22,11 @@ final class EmojiTests : XCTestCase {
 		}
 	}
 	
+#if swift(>=5.2) || (!os(macOS) && !os(iOS) && !os(tvOS) && !os(watchOS))
+	@available(macOS 10.15.4, *)
+	@available(iOS 13.4, *)
+	@available(tvOS 13.4, *)
+	@available(watchOS 6.2, *)
 	func testEmojiAlignmentAndTextRenderingVisually() throws {
 		let envVars = ProcessInfo.processInfo.environment
 		let outputEnvironment: OutputEnvironment = .detect(from: .standardError, envVars)
@@ -30,5 +35,6 @@ final class EmojiTests : XCTestCase {
 			try FileHandle.standardError.write(contentsOf: Data((lineStr + "\n").utf8))
 		}
 	}
+#endif
 	
 }


### PR DESCRIPTION
Related to #6.
We have tested, the compatibility was not good.
It’s fixed now.